### PR TITLE
Update OpenPVSignal.owl

### DIFF
--- a/OpenPVSignal.owl
+++ b/OpenPVSignal.owl
@@ -214,6 +214,9 @@
         <Class IRI="#Summary"/>
     </Declaration>
     <Declaration>
+        <Class IRI="#Vaccine"/>
+    </Declaration>
+    <Declaration>
         <Class IRI="#VigiBase_Report"/>
     </Declaration>
     <Declaration>
@@ -552,6 +555,57 @@
     <Declaration>
         <Datatype abbreviatedIRI="xsd:gYearMonth"/>
     </Declaration>
+    <Declaration>
+        <DataProperty abbreviatedIRI="mp:editedOn"/>
+    </Declaration>
+    <Declaration>
+        <Class abbreviatedIRI="prov:Organization"/>
+    </Declaration>
+    <Declaration>
+        <ObjectProperty abbreviatedIRI="mp:attributedTo"/>
+    </Declaration>
+    <Declaration>
+        <ObjectProperty abbreviatedIRI="mp:hasElement"/>
+    </Declaration>
+    <Declaration>
+        <ObjectProperty abbreviatedIRI="mp:argues"/>
+    </Declaration>
+    <Declaration>
+        <Class abbreviatedIRI="prov:Person"/>
+    </Declaration>
+    <Declaration>
+        <Class abbreviatedIRI="mp:ArticleText"/>
+    </Declaration>
+    <Declaration>
+        <ObjectProperty abbreviatedIRI="mp:supportedByData"/>
+    </Declaration>
+    <Declaration>
+        <ObjectProperty abbreviatedIRI="mp:attributionAsAuthor"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty abbreviatedIRI="mp:publishedOn"/>
+    </Declaration>
+    <Declaration>
+        <Class abbreviatedIRI="mp:Reference"/>
+    </Declaration>
+    <Declaration>
+        <DataProperty abbreviatedIRI="mp:value"/>
+    </Declaration>
+    <Declaration>
+        <Class abbreviatedIRI="mp:Micropublication"/>
+    </Declaration>
+    <Declaration>
+        <ObjectProperty abbreviatedIRI="mp:hasAttribution"/>
+    </Declaration>
+    <Declaration>
+        <Class abbreviatedIRI="prov:Agent"/>
+    </Declaration>
+    <Declaration>
+        <Class abbreviatedIRI="mp:Data"/>
+    </Declaration>
+    <Declaration>
+        <Class abbreviatedIRI="mp:Claim"/>
+    </Declaration>
     <EquivalentClasses>
         <Class abbreviatedIRI="obo:IAO_0000300"/>
         <Class IRI="#Free_text_reporting_element"/>
@@ -595,6 +649,10 @@
     <EquivalentClasses>
         <Class abbreviatedIRI="obo:OGMS_0000031"/>
         <Class IRI="#Condition"/>
+    </EquivalentClasses>
+    <EquivalentClasses>
+        <Class abbreviatedIRI="obo:VO_0000001"/>
+        <Class IRI="#Vaccine"/>
     </EquivalentClasses>
     <SubClassOf>
         <Class IRI="#Adverse_Drug-Drug_interaction"/>
@@ -758,6 +816,10 @@
     <SubClassOf>
         <Class IRI="#Summary"/>
         <Class IRI="#Free_text_reporting_element"/>
+    </SubClassOf>
+    <SubClassOf>
+        <Class IRI="#Vaccine"/>
+        <Class IRI="#Drug"/>
     </SubClassOf>
     <SubClassOf>
         <Class IRI="#VigiBase_Report"/>
@@ -1589,6 +1651,7 @@
             <Literal>CCID_50</Literal>
             <Literal>Ci</Literal>
             <Literal>D&apos;ag&apos;U</Literal>
+            <Literal>DF</Literal>
             <Literal>FFU</Literal>
             <Literal>IU</Literal>
             <Literal>IU/L</Literal>
@@ -1850,6 +1913,7 @@
             <Literal>no recovery</Literal>
             <Literal>permanent injury</Literal>
             <Literal>recovering</Literal>
+            <Literal>recovery after dose reduction</Literal>
             <Literal>recovery after drug withdrawal</Literal>
             <Literal>recovery after hospitalization</Literal>
             <Literal>recovery with no further information</Literal>
@@ -2496,6 +2560,16 @@ group VIII, Practical Aspects of Signal Detection in Pharmacovigilance
         <AnnotationProperty abbreviatedIRI="rdfs:label"/>
         <IRI>#Summary</IRI>
         <Literal xml:lang="en">Summary</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:comment"/>
+        <IRI>#Vaccine</IRI>
+        <Literal>A vaccine is a processed material with the function that when administered, it prevents or ameliorates a disorder in a target organism by inducing or modifying adaptive immune responses specific to the antigens in the vaccine.</Literal>
+    </AnnotationAssertion>
+    <AnnotationAssertion>
+        <AnnotationProperty abbreviatedIRI="rdfs:label"/>
+        <IRI>#Vaccine</IRI>
+        <Literal>Vaccine</Literal>
     </AnnotationAssertion>
     <AnnotationAssertion>
         <AnnotationProperty abbreviatedIRI="rdfs:comment"/>


### PR DESCRIPTION
-Added 'Vaccine' Class, equivalent to vaccine from OBO
-Added 'DF' option on 'has dosage unit'
-Added 'recovery after dose reduction' option on 'refers to outcome after action'